### PR TITLE
Update fab capture_db command and add list_databases command.

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -1,8 +1,12 @@
-from datetime import date
+from datetime import datetime
+import os
 
-from fabric.api import local, env, require, warn_only
-from fabric.utils import puts
-from fabric.colors import blue
+from fabric.api import local, env, require
+from fabric.context_managers import shell_env
+from fabric.contrib.console import confirm
+from fabric.operations import prompt
+from fabric.utils import puts, indent
+from fabric.colors import blue, green
 
 def resetdb():
     local('rm -f coursereviews/default.db')
@@ -26,18 +30,53 @@ def deploy():
     local('heroku run python manage.py collectstatic --noinput')
     local('heroku maintenance:off')
     local('heroku ps')
-    local('heroku open')
+
+def list_databases(middcourses_only='true'):
+    """
+    List all the databases in the currently running PostgreSQL installation.
+
+    By default only list databases beginning with "middcourses".
+    """
+
+    if middcourses_only == 'true':
+        query = 'psql -t -c "select datname from pg_database where datname like \'middcourses%\'"'
+    else:
+        query = 'psql -t -c "select datname from pg_database"'
+
+    databases = local(query, capture=True)
+    databases = [db.strip(' ') for db in databases.split('\n')]
+
+    puts(blue('Databases:'))
+    for db in databases:
+        puts(indent(db, spaces=2))
+
 
 def capture_db():
+    """
+    Create a backup of the production database using Heroku PG Backups.
+    Download the backup to a PostgreSQL dump file.
+    Restore the backup to the locally running PostgreSQL instance.
+    Optionally remove the dump file.
+    """
+
     # We follow the flow outlined here:
     # https://devcenter.heroku.com/articles/heroku-postgres-import-export#export
-    db_name = 'middcourses-{:%Y-%m-%d}'.format(date.today())
+    now = datetime.now().replace(microsecond=0)
+    db_name = 'middcourses-{0}'.format(now.isoformat())
 
-    # We do not want to abort on unreconized parameter "lock_timeout"
-    with warn_only():
-        local('heroku pgbackups:capture')
-        local('curl -o {0}.dump `heroku pgbackups:url`'.format(db_name))
-        local('createdb {0}'.format(db_name))
-        local('pg_restore --no-acl --no-owner -h localhost -U {0} -d {1} "{1}.dump"'.format(env.user, db_name))
+    puts(blue('Creating a backup.'))
+    local('heroku pg:backups capture')
 
-        puts(blue('PostgreSQL database {0} created'.format(db_name)))
+    puts(blue('Downloading the backup.'))
+    local('curl -o {0}.dump `heroku pg:backups public-url`'.format(db_name))
+
+    puts(blue('Restoring the database to PostgreSQL.'))
+    local('createdb {0}'.format(db_name))
+    local('pg_restore --no-acl --no-owner -h localhost -U {0} -d {1} "{1}.dump"'.format(env.user, db_name))
+
+    puts(green('PostgreSQL database {0} created.'.format(db_name)))
+
+    remove = confirm('Remove "{0}.dump"?'.format(db_name))
+
+    if remove:
+        local('rm {0}.dump'.format(db_name))


### PR DESCRIPTION
`capture_db' updated to work with the new Heroku Postgres Backups
and use the current time as well as date for the database name.

`list_databases' lists all databases in the currently running local
PostgreSQL instance, using psql. By default it only lists databases
starting with "middcourses" since this is the format downloaded by
`capture_db'. Useful for setting the development database to test
with production data.